### PR TITLE
Merge address fixes from Dev

### DIFF
--- a/src/servers/http/routes/qos.rs
+++ b/src/servers/http/routes/qos.rs
@@ -45,22 +45,17 @@ struct QosQuery {
 async fn qos(Query(query): Query<QosQuery>) -> Xml {
     debug!("Recieved QOS query: (Port: {})", query.port);
 
-    let public_ip = public_address()
-        .await
-        .map(|value| NetAddress::from_ipv4(&value))
-        .unwrap_or_default();
-
     let port: u16 = env::from_env(env::QOS_PORT);
 
     let response = format!(
         r"<qos> <numprobes>0</numprobes>
     <qosport>{}</qosport>
     <probesize>0</probesize>
-    <qosip>{}</qosip>
+    <qoshost>gosredirector.ea.com</qoshost>
     <requestid>1</requestid>
     <reqsecret>0</reqsecret>
 </qos>",
-        port, public_ip.0
+        port,
     );
     Xml(response)
 }

--- a/src/utils/models.rs
+++ b/src/utils/models.rs
@@ -389,10 +389,7 @@ impl Debug for NetAddress {
 impl Display for NetAddress {
     /// Converts the value stored in this NetAddress to an IPv4 string
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let a: u8 = ((self.0 >> 24) & 0xFF) as u8;
-        let b: u8 = ((self.0 >> 16) & 0xFF) as u8;
-        let c: u8 = ((self.0 >> 8) & 0xFF) as u8;
-        let d: u8 = (self.0 & 0xFF) as u8;
+        let [a, b, c, d] = self.0.to_be_bytes();
         write!(f, "{a}.{b}.{c}.{d}")
     }
 }

--- a/src/utils/net.rs
+++ b/src/utils/net.rs
@@ -62,7 +62,7 @@ pub async fn public_address() -> Option<Ipv4Addr> {
 
     // If we couldn't connect to any IP services its likely
     // we don't have internet lets try using our local address
-    {
+    if value.is_none() {
         if let Ok(IpAddr::V4(addr)) = local_ip_address::local_ip() {
             value = Some(addr)
         }


### PR DESCRIPTION
Fixed condition for checking that a public address could not be found to fallback to the local address 

Use a host field for QOS lookups instead of using the machine public address 

Directly wrapping Ipv4 address with Netaddress instead of converting first