### PR TITLE
Server side portion of client proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,7 +1382,7 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "pocket-relay"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "argon2",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-relay"
-version = "0.5.6"
+version = "0.5.7"
 description = "Pocket Relay Server"
 readme = "README.md"
 keywords = ["EA", "PocketRelay", "MassEffect"]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -107,6 +107,7 @@ pub struct SessionHostTarget {
     pub scheme: BlazeScheme,
     pub host: Box<str>,
     pub port: Port,
+    pub local_http: bool,
 }
 
 #[derive(Message)]

--- a/src/session/models/util.rs
+++ b/src/session/models/util.rs
@@ -30,6 +30,8 @@ const TELEMETRY_KEY: &[u8] = &[
 pub const TICKER_PORT: Port = 8999;
 /// The constant port for the telemetry server
 pub const TELEMETRY_PORT: Port = 42129;
+// The constant port for the local http server
+pub const LOCAL_HTTP_PORT: Port = 42131;
 
 /// Structure for encoding the telemetry server details
 pub struct TelemetryServer;
@@ -126,10 +128,16 @@ impl Encodable for PreAuthResponse {
 
         // Quality Of Service Server details
         writer.group(b"QOSS", |writer| {
+            let (http_host, http_port) = if self.host_target.local_http {
+                ("127.0.0.1", LOCAL_HTTP_PORT)
+            } else {
+                (&self.host_target.host as &str, self.host_target.port)
+            };
+
             // Bioware Primary Server
             writer.group(b"BWPS", |writer| {
-                writer.tag_str(b"PSA", &self.host_target.host);
-                writer.tag_u16(b"PSP", self.host_target.port);
+                writer.tag_str(b"PSA", http_host);
+                writer.tag_u16(b"PSP", http_port);
                 writer.tag_str(b"SNA", "prod-sjc");
             });
 
@@ -144,8 +152,8 @@ impl Encodable for PreAuthResponse {
                 writer.write_str("ea-sjc");
 
                 // Same as the Bioware primary server
-                writer.tag_str(b"PSA", &self.host_target.host);
-                writer.tag_u16(b"PSP", self.host_target.port);
+                writer.tag_str(b"PSA", http_host);
+                writer.tag_u16(b"PSP", http_port);
                 writer.tag_str(b"SNA", "prod-sjc");
                 writer.tag_group_end();
             }

--- a/src/session/routes/util.rs
+++ b/src/session/routes/util.rs
@@ -436,13 +436,19 @@ async fn data_config(session: &SessionLink) -> TdfMap<String, String> {
         Ok(value) => value,
         Err(_) => return TdfMap::with_capacity(0),
     };
+
+    let prefix = if host_target.local_http {
+        format!("http://127.0.0.1:{}", LOCAL_HTTP_PORT)
+    } else {
+        format!(
+            "{}{}:{}",
+            host_target.scheme.value(),
+            host_target.host,
+            host_target.port
+        )
+    };
+
     let tele_port = TELEMETRY_PORT;
-    let prefix = format!(
-        "{}{}:{}",
-        host_target.scheme.value(),
-        host_target.host,
-        host_target.port
-    );
 
     let mut config = TdfMap::with_capacity(15);
     config.insert("GAW_SERVER_BASE_URL", format!("{prefix}/"));


### PR DESCRIPTION
## Description

This changes implements server side support for handling HTTP locally and proxing requests to the server as per https://github.com/PocketRelay/Client/issues/11

## Changes
- Implemented handling for `X-Pocket-Relay-Local-Http` upgrade header to handle using local HTTP instead

## Related Issues

- Closes #47 