### PR TITLE
feat: new public games api configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ pub struct RuntimeConfig {
     pub menu_message: String,
     pub dashboard: DashboardConfig,
     pub tunnel: TunnelConfig,
+    pub api: APIConfig,
 }
 
 /// Environment variable key to load the config from
@@ -78,6 +79,7 @@ pub struct Config {
     pub logging: LevelFilter,
     pub retriever: RetrieverConfig,
     pub tunnel: TunnelConfig,
+    pub api: APIConfig,
 }
 
 impl Default for Config {
@@ -92,7 +94,8 @@ impl Default for Config {
             galaxy_at_war: Default::default(),
             logging: LevelFilter::Info,
             retriever: Default::default(),
-            tunnel: Default::default()
+            tunnel: Default::default(),
+            api: Default::default()
         }
     }
 }
@@ -131,6 +134,24 @@ pub enum QosServerConfig {
         /// The address of the host computer (Required for 127.0.0.1 resolution)
         host: Ipv4Addr,
     },
+}
+
+#[derive(Deserialize)]
+#[serde(default)]
+pub struct APIConfig {
+    /// Allow games data to be requested from the API without auth
+    pub public_games: bool,
+    /// Hide players from API response when no auth is provided
+    pub public_games_hide_players: bool,
+}
+
+impl Default for APIConfig {
+    fn default() -> Self {
+        Self {
+            public_games: false,
+            public_games_hide_players: true,
+        }
+    }
 }
 
 #[derive(Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ async fn main() {
         dashboard: config.dashboard,
         qos: config.qos,
         tunnel: config.tunnel,
+        api: config.api,
     };
 
     debug!("QoS server: {:?}", &runtime_config.qos);

--- a/src/routes/gaw.rs
+++ b/src/routes/gaw.rs
@@ -1,5 +1,5 @@
 //! Routes for the Galaxy At War API used by the Mass Effect 3 client in order
-//! to retrieve and increase the Galxay At War values for a player.
+//! to retrieve and increase the Galaxy At War values for a player.
 //!
 //! This API is not documented as it is not intended to be used by anyone
 //! other than the Mass Effect 3 client itself.
@@ -90,7 +90,7 @@ pub async fn shared_token_login(Query(AuthQuery { auth }): Query<AuthQuery>) -> 
 /// GET /galaxyatwar/getRatings/:id
 ///
 /// Route for retrieving the galaxy at war ratings for the player
-/// with the provied ID
+/// with the provided ID
 ///
 /// `id` The hex encoded ID of the player
 pub async fn get_ratings(

--- a/src/services/game/manager.rs
+++ b/src/services/game/manager.rs
@@ -83,6 +83,7 @@ impl GameManager {
         offset: usize,
         count: usize,
         include_net: bool,
+        include_players: bool,
     ) -> (Vec<GameSnapshot>, bool) {
         // Create the futures using the handle action before passing
         // them to a future to be awaited
@@ -111,7 +112,7 @@ impl GameManager {
                 .for_each(|game| {
                     join_set.spawn(async move {
                         let game = &*game.read().await;
-                        game.snapshot(include_net)
+                        game.snapshot(include_net, include_players)
                     });
                 });
 

--- a/src/services/game/mod.rs
+++ b/src/services/game/mod.rs
@@ -68,7 +68,7 @@ pub struct GameSnapshot {
     /// The game attributes
     pub attributes: AttrMap,
     /// Snapshots of the game players
-    pub players: Box<[GamePlayerSnapshot]>,
+    pub players: Option<Box<[GamePlayerSnapshot]>>,
 }
 
 /// Attributes map type
@@ -423,13 +423,17 @@ impl Game {
         GameJoinableState::Joinable
     }
 
-    pub fn snapshot(&self, include_net: bool) -> GameSnapshot {
-        let players = self
-            .players
-            .iter()
-            .map(|value| value.snapshot(include_net))
-            .collect();
-
+    pub fn snapshot(&self, include_net: bool, include_players: bool) -> GameSnapshot {
+        let players = if include_players {
+            let players = self
+                .players
+                .iter()
+                .map(|value| value.snapshot(include_net))
+                .collect();
+            Some(players)
+        } else {
+            None
+        };
         GameSnapshot {
             id: self.id,
             state: self.state,


### PR DESCRIPTION
Adds the option to allow requesting the actively running list of games from the server without requiring authentication

This adds two new config options under a new `api` section, below are the default values:

```
{
    "api": {
        "public_games": false,
        "public_games_hide_players": true
    }
}
```

Setting `public_games` to true will allow anyone to request the `/api/games` endpoint without requiring auth, by default the details about the players of the game are not included in this response unless the user is authenticated. You can allow unauthenticated users to see the players in each game by setting `public_games_hide_players` to false.

> [!WARNING]
> Set `public_games_hide_players` to false at your own discretion, accounts created through the in-game account creator will expose the user email as their player name if this is enabled (Unless they change their name in the server dashboard which is recommended)