### PR TITLE
feat: improved games api

### DIFF
--- a/src/services/game/manager.rs
+++ b/src/services/game/manager.rs
@@ -15,6 +15,7 @@ use crate::{
         types::{GameID, PlayerID},
     },
 };
+use chrono::Utc;
 use log::{debug, warn};
 use std::{
     collections::VecDeque,
@@ -209,10 +210,12 @@ impl GameManager {
         setting: GameSettings,
     ) -> (GameRef, GameID) {
         let id = self.next_id.fetch_add(1, Ordering::AcqRel);
+        let created_at = Utc::now();
         let game = Game::new(
             id,
             attributes,
             setting,
+            created_at,
             self.clone(),
             self.tunnel_service.clone(),
         );

--- a/src/services/game/mod.rs
+++ b/src/services/game/mod.rs
@@ -69,6 +69,8 @@ pub struct GameSnapshot {
     pub attributes: AttrMap,
     /// Snapshots of the game players
     pub players: Option<Box<[GamePlayerSnapshot]>>,
+    /// The total number of players in the game
+    pub total_players: usize,
 }
 
 /// Attributes map type
@@ -424,6 +426,7 @@ impl Game {
     }
 
     pub fn snapshot(&self, include_net: bool, include_players: bool) -> GameSnapshot {
+        let total_players: usize = self.players.len();
         let players = if include_players {
             let players = self
                 .players
@@ -434,12 +437,14 @@ impl Game {
         } else {
             None
         };
+
         GameSnapshot {
             id: self.id,
             state: self.state,
             setting: self.settings.bits(),
             attributes: self.attributes.clone(),
             players,
+            total_players,
         }
     }
 

--- a/src/services/game/mod.rs
+++ b/src/services/game/mod.rs
@@ -22,6 +22,7 @@ use crate::{
         types::{GameID, PlayerID},
     },
 };
+use chrono::{DateTime, Utc};
 use log::{debug, warn};
 use serde::Serialize;
 use std::sync::{Arc, Weak};
@@ -40,19 +41,19 @@ pub type WeakGameRef = Weak<RwLock<Game>>;
 pub struct Game {
     /// Unique ID for this game
     pub id: GameID,
-
     /// The current game state
     pub state: GameState,
     /// The current game setting
     pub settings: GameSettings,
     /// The game attributes
     pub attributes: AttrMap,
-
+    /// When the game was started
+    pub created_at: DateTime<Utc>,
+    /// Players currently in the game
     pub players: Vec<GamePlayer>,
-
     /// Services access
     pub game_manager: Arc<GameManager>,
-
+    /// Access to the tunneling service
     pub tunnel_service: Arc<TunnelService>,
 }
 
@@ -71,6 +72,8 @@ pub struct GameSnapshot {
     pub players: Option<Box<[GamePlayerSnapshot]>>,
     /// The total number of players in the game
     pub total_players: usize,
+    /// When the game was created
+    pub created_at: DateTime<Utc>,
 }
 
 /// Attributes map type
@@ -217,6 +220,7 @@ impl Game {
         id: GameID,
         attributes: AttrMap,
         settings: GameSettings,
+        created_at: DateTime<Utc>,
         game_manager: Arc<GameManager>,
         tunnel_service: Arc<TunnelService>,
     ) -> Game {
@@ -226,6 +230,7 @@ impl Game {
             settings,
             state: Default::default(),
             players: Default::default(),
+            created_at,
             game_manager,
             tunnel_service,
         }
@@ -445,6 +450,7 @@ impl Game {
             attributes: self.attributes.clone(),
             players,
             total_players,
+            created_at: self.created_at,
         }
     }
 


### PR DESCRIPTION
Games now store their creation time and the games API response includes the total players in a game along with the creation time for the game.

Below is an example of an unauthenticated API request to the games API `/api/games`:

```json
{
    "games": [
        {
            "id": 1,
            "state": "PreGame",
            "setting": 285,
            "attributes": {
                "ME3_dlc2500": "required",
                "ME3gameDifficulty": "difficulty0",
                "ME3gameEnemyType": "enemy1",
                "ME3gameState": "IN_LOBBY",
                "ME3map": "map2",
                "ME3privacy": "PRIVATE"
            },
            "players": null,
            "total_players": 1,
            "created_at": "2024-05-11T03:52:59.688572600Z"
        }
    ],
    "more": false,
    "total_items": 1
}
```